### PR TITLE
Fix memory leak in bz_reader_read

### DIFF
--- a/ext/bzip2/reader.c
+++ b/ext/bzip2/reader.c
@@ -316,6 +316,7 @@ VALUE bz_reader_read(int argc, VALUE *argv, VALUE obj) {
         OBJ_TAINT(res);
     }
     if (n == 0) {
+        free(bzf->buf);
         return res;
     }
     while (1) {
@@ -325,12 +326,14 @@ VALUE bz_reader_read(int argc, VALUE *argv, VALUE obj) {
             res = rb_str_cat(res, bzf->bzs.next_out, n);
             bzf->bzs.next_out += n;
             bzf->bzs.avail_out -= n;
+            free(bzf->buf);
             return res;
         }
         if (total) {
             res = rb_str_cat(res, bzf->bzs.next_out, total);
         }
         if (bz_next_available(bzf, 0) == BZ_STREAM_END) {
+            free(bzf->buf);
             return res;
         }
     }


### PR DESCRIPTION
bz_reader_read never frees any of the buffers it allocates for uncompressed data.  

I found this behavior to be sub-optimal so I made it free the buffers before returning the ruby string.  Probably a better way to do this, but at least Bzip2.uncompress doesn't leak anymore...
