### PR TITLE
Fix to build bzip2-ruby with Rubinius.

### DIFF
--- a/ext/bzip2/writer.c
+++ b/ext/bzip2/writer.c
@@ -161,9 +161,11 @@ VALUE bz_writer_close(VALUE obj) {
 
     Get_BZ2(obj, bzf);
     res = bz_writer_internal_close(bzf);
+#ifndef RUBINIUS
     if (!NIL_P(res) && (bzf->flags & BZ2_RB_INTERNAL)) {
         RBASIC(res)->klass = rb_cString;
     }
+#endif
     return res;
 }
 


### PR DESCRIPTION
This code is not supportable on Rubinius and is generally very bad practice. Bzip2 does
not own the Ruby class data structures and should not make any assumptions about them.

In this case, the code appears entirely unnecessary because the value is created as
a String in the first place.

I'm not sure what is the best fix, but this would at least allow compiling on Rubinius.

FWIW, there are numerous bad practices in this C extension, such as relying on MRI
C globals like rb_rs instead of getting the value of the $/ Ruby global and depending
on the internals of RFile. I've added basic RFile support to Rubinius just to support
building this C-extension, but there are limits to what I can do.
