### PR TITLE
Updated source in Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,3 @@
-source :gemcutter
+source 'https://rubygems.org'
 
 gemspec


### PR DESCRIPTION
:rubygems is deprecated as of Bundler 1.2.4
