### PR TITLE
Fixed extconf.rb for Ruby 2.0

### DIFF
--- a/ext/bzip2/extconf.rb
+++ b/ext/bzip2/extconf.rb
@@ -11,7 +11,7 @@ if have_library("bz2", "BZ2_bzWriteOpen")
      $static = nil
   end
 
-  if RUBY_VERSION =~ /1.9/
+  if RUBY_VERSION.to_f >= 1.9
     $CFLAGS << ' -DRUBY_19_COMPATIBILITY'
   end
   


### PR DESCRIPTION
Define `RUBY_19_COMPATIBILITY` for all Ruby versions 1.9+.
