### PR TITLE
Set dependencies with ~> to prevent major verion breakage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,15 +3,13 @@ rvm:
   - 1.8.7
   - 1.9.2
   - 1.9.3
-  - rbx
+  - 2.0.0
+  - 2.1.2
+  - rbx-2
   - ree
-  - ruby-head
-  - rbx-18mode
-  - rbx-19mode
 matrix:
   allow_failures:
-    - rvm: rbx-18mode
-    - rvm: rbx-19mode
+    - rvm: rbx-2
 script:
   - bundle exec rake
   - bundle exec rspec

--- a/bzip2-ruby.gemspec
+++ b/bzip2-ruby.gemspec
@@ -16,6 +16,7 @@ Gem::Specification.new do |s|
   s.test_files = `git ls-files spec`.split("\n")
 
   # tests
-  s.add_development_dependency 'rake-compiler', ">= 0.7.5"
-  s.add_development_dependency 'rspec', ">= 2.0.0"
+  s.add_development_dependency 'rake-compiler', '~> 0.8.0'
+  s.add_development_dependency 'rake', '~> 0.9.3'
+  s.add_development_dependency 'rspec', '~> 2.8.0'
 end

--- a/ext/bzip2/common.c
+++ b/ext/bzip2/common.c
@@ -16,7 +16,7 @@ void bz_free(void *opaque, void *p) {
     free(p);
 }
 
-VALUE bz_raise(int error) {
+void bz_raise(int error) {
     VALUE exc;
     const char *msg;
 

--- a/ext/bzip2/common.h
+++ b/ext/bzip2/common.h
@@ -44,7 +44,6 @@ struct bz_iv {
         rb_raise(rb_eIOError, "closed IO");     \
     }
 
-#ifndef ASDFasdf
 extern VALUE bz_cWriter, bz_cReader, bz_cInternal;
 extern VALUE bz_eError, bz_eEOZError;
 
@@ -52,7 +51,6 @@ extern VALUE bz_internal_ary;
 
 extern ID id_new, id_write, id_open, id_flush, id_read;
 extern ID id_closed, id_close, id_str;
-#endif
 
 void bz_file_mark(struct bz_file * bzf);
 void* bz_malloc(void *opaque, int m, int n);

--- a/ext/bzip2/common.h
+++ b/ext/bzip2/common.h
@@ -18,20 +18,6 @@
 #define DEFAULT_BLOCKS 9
 #define ASIZE (1 << CHAR_BIT)
 
-/* Older versions of Ruby (< 1.8.6) need these */
-#ifndef RSTRING_PTR
-#  define RSTRING_PTR(s) (RSTRING(s)->ptr)
-#endif
-#ifndef RSTRING_LEN
-#  define RSTRING_LEN(s) (RSTRING(s)->len)
-#endif
-#ifndef RARRAY_PTR
-#  define RARRAY_PTR(s) (RARRAY(s)->ptr)
-#endif
-#ifndef RARRAY_LEN
-#  define RARRAY_LEN(s) (RARRAY(s)->len)
-#endif
-
 struct bz_file {
     bz_stream bzs;
     VALUE in, io;

--- a/ext/bzip2/common.h
+++ b/ext/bzip2/common.h
@@ -55,6 +55,6 @@ extern ID id_closed, id_close, id_str;
 void bz_file_mark(struct bz_file * bzf);
 void* bz_malloc(void *opaque, int m, int n);
 void bz_free(void *opaque, void *p);
-VALUE bz_raise(int err);
+void bz_raise(int err);
 
 #endif

--- a/ext/bzip2/reader.c
+++ b/ext/bzip2/reader.c
@@ -334,8 +334,6 @@ VALUE bz_reader_read(int argc, VALUE *argv, VALUE obj) {
             return res;
         }
     }
-    xfree(bzf->buf);
-    bzf->buf = NULL;
     return Qnil;
 }
 

--- a/ext/bzip2/reader.c
+++ b/ext/bzip2/reader.c
@@ -327,16 +327,12 @@ VALUE bz_reader_read(int argc, VALUE *argv, VALUE obj) {
             res = rb_str_cat(res, bzf->bzs.next_out, n);
             bzf->bzs.next_out += n;
             bzf->bzs.avail_out -= n;
-            xfree(bzf->buf);
-            bzf->buf = NULL;
             return res;
         }
         if (total) {
             res = rb_str_cat(res, bzf->bzs.next_out, total);
         }
         if (bz_next_available(bzf, 0) == BZ_STREAM_END) {
-            xfree(bzf->buf);
-            bzf->buf = NULL;
             return res;
         }
     }

--- a/ext/bzip2/reader.c
+++ b/ext/bzip2/reader.c
@@ -316,8 +316,6 @@ VALUE bz_reader_read(int argc, VALUE *argv, VALUE obj) {
         OBJ_TAINT(res);
     }
     if (n == 0) {
-        xfree(bzf->buf);
-        bzf->buf = NULL;
         return res;
     }
     while (1) {
@@ -336,6 +334,8 @@ VALUE bz_reader_read(int argc, VALUE *argv, VALUE obj) {
             return res;
         }
     }
+    xfree(bzf->buf);
+    bzf->buf = NULL;
     return Qnil;
 }
 


### PR DESCRIPTION
Recent PRs #25 and #26 failed because rspec 3.0 matches ">= 2.0.0". This PR pins rspec, rake, rake-compiler as needed.
